### PR TITLE
Added PastProjectCard mobile queries for resizing and removed text 

### DIFF
--- a/frontend/src/components/our_work/PastProjects.tsx
+++ b/frontend/src/components/our_work/PastProjects.tsx
@@ -49,7 +49,7 @@ const PastProjects: React.FC = () => {
   });
 
   return (
-    <div>
+    <div className={styles.pastProjectsContainer}>
       <h2 id={styles.sectionTitle}>Past Projects</h2>
       <div id={styles.searchbarWrapper}>
         <img

--- a/frontend/src/styles/our_work/PastProjectCard.module.css
+++ b/frontend/src/styles/our_work/PastProjectCard.module.css
@@ -43,12 +43,6 @@
   text-decoration: none;
 }
 
-#cardTitle h3 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 #cardDateContainer h3 {
   font-style: italic;
   width: 100%;

--- a/frontend/src/styles/our_work/PastProjectCard.module.css
+++ b/frontend/src/styles/our_work/PastProjectCard.module.css
@@ -70,3 +70,18 @@
   animation-timing-function: ease-out;
   animation-duration: 300ms;
 }
+
+@media screen and (max-width: 1000px){
+  #cardContainer {
+    align-items: center;
+    justify-content: center;
+    width: 40%;
+    margin-bottom: 50px;
+  }
+}
+
+@media screen and (max-width: 800px){
+  #cardContainer {
+    width: 100%;
+  }
+}

--- a/frontend/src/styles/our_work/PastProjectCard.module.css
+++ b/frontend/src/styles/our_work/PastProjectCard.module.css
@@ -40,9 +40,12 @@
 }
 
 #cardTitle {
+  text-decoration: none;
+}
+
+#cardTitle h3 {
   overflow: hidden;
   text-overflow: ellipsis;
-  text-decoration: none;
   white-space: nowrap;
 }
 

--- a/frontend/src/styles/our_work/PastProjects.module.css
+++ b/frontend/src/styles/our_work/PastProjects.module.css
@@ -50,3 +50,14 @@
   margin-top: 50px;
   gap: 12.5% 10%;
 }
+
+.pastProjectsContainer {
+  padding-top: 30px;
+}
+
+@media screen and (max-width: 800px){
+  #projectsDisplay {
+    margin-top: 20px;
+    display: block;
+  }
+} 


### PR DESCRIPTION
Added queries for smaller screen and mobile resizing for past project cards. 
* Made a new class `pastProjectsContainer` to house all the projects and apply styling to them 
    * Just resizes the width of each card per media query
* Note there are queries for two screen size, 1000 and 800. This is is in part under the guidance of [this article](https://www.freecodecamp.org/news/css-media-queries-breakpoints-media-types-standard-resolutions-and-more/) but also because the past projects naturally should go 3 columns -> 2 -> 1 big column and the 800 and 1000 screensizes for the project cards fit nicely 
    * apt to change at any time however. 

Removed the ellipses styling that was applied to the headers in the pastproject cards for now: 
`
#cardTitle h3 {
  overflow: hidden;
  text-overflow: ellipsis;
  white-space: nowrap;
}`

since there was no spec in the figma for it