### PR TITLE
Fix Featured Projects styling

### DIFF
--- a/frontend/src/components/home_page/FeaturedProjectCard.tsx
+++ b/frontend/src/components/home_page/FeaturedProjectCard.tsx
@@ -21,18 +21,20 @@ const FeaturedProjectCard = ({ link, title, date, summary, image, altText }: Fea
         </a>
       </div>
       <div id={styles.cardTextContainer}>
-        <div id={styles.cardHeadingContainer}>
-          <div id={styles.cardTitleContainer}>
-            <a id={styles.cardTitle} href={link}>
-              <h3>{title}</h3>
-            </a>
+        <div id={styles.cardVariableTextContainer}>
+          <div id={styles.cardHeadingContainer}>
+            <div id={styles.cardTitleContainer}>
+              <a id={styles.cardTitle} href={link}>
+                <h3>{title}</h3>
+              </a>
+            </div>
+            <div id={styles.cardDateContainer}>
+              <h3>{date}</h3>
+            </div>
           </div>
-          <div id={styles.cardDateContainer}>
-            <h3>{date}</h3>
+          <div id={styles.cardSummary}>
+            <p>{summary}</p>
           </div>
-        </div>
-        <div id={styles.cardSummary}>
-          <p>{summary}</p>
         </div>
         <div id={styles.cardLinkContainer}>
           <a id={styles.cardLink} href={link}>

--- a/frontend/src/components/home_page/FeaturedProjects.tsx
+++ b/frontend/src/components/home_page/FeaturedProjects.tsx
@@ -27,9 +27,7 @@ const FeaturedProjects = () => {
            ))}
         </div>
         <div className={styles.seeMore} >
-          <a href='/ourwork' className={styles.buttonLink}>
-            <StandardButton text="See More" color="blue" link="/ourwork" />
-          </a>
+          <StandardButton text="See More" color="blue" link="/ourwork" />
         </div>
       </div>
   );

--- a/frontend/src/styles/home/FeaturedProjectCard.module.css
+++ b/frontend/src/styles/home/FeaturedProjectCard.module.css
@@ -32,7 +32,7 @@
 }
 
 #cardTitleContainer {
-  text-align: center;
+  text-align: left;
 }
 
 #cardTitle {
@@ -40,7 +40,7 @@
 }
 
 #cardDateContainer {
-  text-align: center;
+  text-align: left;
 }
 
 #cardDateContainer h3 {
@@ -50,11 +50,11 @@
 #cardSummary {
   overflow: hidden;
   text-overflow: ellipsis;
-  text-align: center;
+  text-align: left;
 }
 
 #cardLinkContainer {
-  text-align: center;
+  text-align: left;
   height: 30px;
 }
 

--- a/frontend/src/styles/home/FeaturedProjectCard.module.css
+++ b/frontend/src/styles/home/FeaturedProjectCard.module.css
@@ -1,33 +1,19 @@
-
 #cardContainer {
-  margin-top: 0px;
-  margin-bottom: 3vw;
-  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 15vw;
 }
 
 #cardImageContainer {
-  flex: 0.35;
   border-color: #333333;
   justify-content: center;
   align-items: center;
   overflow: hidden;
-  display: flex;
-  width: 300px;
+  width: auto;
   height: 200px;
   border-radius: 50px;
-}
-
-#cardTextContainer {
-  flex: 0.65;
-  left: 0;
-  top: 0;
-  margin-left: 2vw;
-  max-height: 200px;
-  height: 200px;
-}
-
-#cardHeadingContainer {
-  display: flex;
+  margin-bottom: 7vw;
 }
 
 #cardImage {
@@ -37,23 +23,24 @@
   object-fit: cover;
 }
 
+#cardTextContainer {
+  margin-left: 0;
+}
+
+#cardHeadingContainer {
+  display: block;
+}
+
 #cardTitleContainer {
-  flex: 0.7;
-  text-align: left;
+  text-align: center;
 }
 
 #cardTitle {
-  overflow: hidden;
-  text-overflow: ellipsis;
   text-decoration: none;
-  white-space: nowrap;
 }
 
 #cardDateContainer {
   text-align: center;
-  flex: 0.3;
-  right: 0;
-  top: 0;
 }
 
 #cardDateContainer h3 {
@@ -61,18 +48,14 @@
 }
 
 #cardSummary {
-  max-height: 70%;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: pre-line;
-  padding-top: 2%;
-  padding-bottom: 1%;
-  text-align: left;
+  text-align: center;
 }
 
 #cardLinkContainer {
-  flex: 1;
-  text-align: left;
+  text-align: center;
+  height: 30px;
 }
 
 #cardLink {
@@ -85,19 +68,72 @@
   transition: color 300ms ease;
 }
 
+@media screen and (min-width: 700px){
 
-@media screen and (max-width: 1000px){
   #cardContainer {
-    display: block;
-    margin-left: 3em;
-    margin-right: 3em;
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 5vw;
+  }
+
+  #cardImageContainer {
+    display: flex;
+    flex: 0.35;
+    margin-bottom: 0;
+  }  
+
+  #cardTextContainer {
+    flex: 0.65;
+    right: 0;
+    top: 0;
+    margin-left: 2vw;
+    margin-top: 0;
+    flex-direction: column;
+    height: 200px;
+  }
+
+  #cardVariableTextContainer {
+    height:calc(100% - 30px);
+    display: flex;
+    flex-direction: column;
   }
 
   #cardHeadingContainer {
-    display: block;
+    display: flex;
+    top: 0;
+    width: auto;
+  }
+
+  #cardTitleContainer {
+    flex: 0.7;
+    text-align: left;
+  }
+
+  #cardTitle {
+    overflow: hidden;
+    text-decoration: none;
   }
 
   #cardDateContainer {
+    text-align: right;
+    flex: 0.3;
+    left: 0;
+    top: 0;
+  }
+
+  #cardSummary {
+    padding-top: 2%;
+    padding-bottom: 1%;
+    text-align: left;
+    height: auto;
+    width: auto;
+    justify-content: flex-start;
+    flex: 1;
+  }
+
+  #cardLinkContainer {
+    bottom: 0;
     text-align: left;
   }
+
 }

--- a/frontend/src/styles/home/FeaturedProjects.module.css
+++ b/frontend/src/styles/home/FeaturedProjects.module.css
@@ -1,15 +1,19 @@
-.center {
-  min-height: 350px;
-  text-align: center;
-  position: relative;
-  margin-top: -25%;
-}
-
 .featuredProjectCards {
-  margin-left: 20%;
-  margin-right: 20%;
+  margin-left: 10%;
+  margin-right: 10%;
+  justify-content: center;
+  align-items: center;
 }
 
 .seeMore {
   text-align: center;
+}
+
+@media screen and (min-width: 700px) {
+
+  .featuredProjectCards {
+    margin-left: 20%;
+    margin-right: 20%;
+  }
+
 }

--- a/frontend/src/styles/home/FeaturedProjects.module.css
+++ b/frontend/src/styles/home/FeaturedProjects.module.css
@@ -1,19 +1,16 @@
 .featuredProjectCards {
   margin-left: 10%;
   margin-right: 10%;
-  justify-content: center;
-  align-items: center;
 }
 
 .seeMore {
   text-align: center;
 }
 
-@media screen and (min-width: 700px) {
+@media screen and (min-width: 1000px) {
 
   .featuredProjectCards {
-    margin-left: 20%;
-    margin-right: 20%;
+    margin: 0 12%;
   }
 
 }


### PR DESCRIPTION
Update styling of the Featured Projects component and the Featured
Projects card to be mobile first

Decrease margins in mobile view of Featured Projects section

Change styling of Featured Projects card to fix overlapping cards and
improve layout while zooming in and out

Fix mobile view of Featured Projects section

Updates also appear to have fixed overlapping cards in Current Projects
section of Our Work page