### PR TITLE
 Fix navbar items overlapping with FAQ questions

### DIFF
--- a/frontend/src/styles/apply/Faq.module.css
+++ b/frontend/src/styles/apply/Faq.module.css
@@ -24,7 +24,7 @@
   /* position and z index ensures that invisible text will be behind the
    * questions */
   position: relative;
-  z-index: 5;
+  z-index: 2;
 }
 
 .question h3 {
@@ -61,12 +61,6 @@
   opacity: 0;
   max-height: 0;
   transition: max-height 300ms 0ms, opacity 300ms linear;
-}
-
-.answer.showing {
-  /* Above footer, below questions */
-  position: relative;
-  z-index: 3;
 }
 
 .answer.showing p {

--- a/frontend/src/styles/navbar/Navbar.module.css
+++ b/frontend/src/styles/navbar/Navbar.module.css
@@ -140,7 +140,7 @@
   position: fixed;
   width: 100vw;
   height: 100vh;
-  z-index: 2;
+  z-index: 5;
 }
 
 /* Mobile Styles */


### PR DESCRIPTION
- Fixed by changing z-index values.
- Also removed z-index for FAQ answers. Originally added to allow the questions to layer over footer, but didn't seem to be necessary.