### PR TITLE
Project image styling

### DIFF
--- a/frontend/src/styles/home/FeaturedProjectCard.module.css
+++ b/frontend/src/styles/home/FeaturedProjectCard.module.css
@@ -21,6 +21,7 @@
   min-width: 100%;
   min-height: 100%;
   object-fit: cover;
+  max-width: 400px;
 }
 
 #cardDetailsContainer {

--- a/frontend/src/styles/our_work/PastProjectCard.module.css
+++ b/frontend/src/styles/our_work/PastProjectCard.module.css
@@ -23,6 +23,7 @@
   min-width: 100%;
   min-height: 100%;
   object-fit: cover;
+  max-width: 400px;
 }
 
 #cardTextContainer {

--- a/frontend/src/styles/projects/ProjectsTop.module.css
+++ b/frontend/src/styles/projects/ProjectsTop.module.css
@@ -43,6 +43,10 @@
   margin: 4px;
 }
 
+.projectPicture img {
+  width: 500px;
+}
+
 .projectInfoContainer {
   width: 75vw;
   display: flex;


### PR DESCRIPTION
Added max-width to `FeaturedProjectsCard` and `CurrentProjectsCard`, and `PastProjects` card to be 400px, and max-width on individual projects page to be 500px. 

This causes 
- In normal screen sizing and mobile screen sizing, images on these cards and project pages with variable sizing will have widths that span their containers 
![image](https://user-images.githubusercontent.com/45301066/184518147-893694cd-26b5-4f7d-8165-eeab65441848.png)

- When screen is small, image may not fill in entire container. This can be addressed in a future commit 

Considerations we might want to make in the future
 - Whether or not to just implement some image resizing capabilities in strapi backend so we don't have to think about this in front end
 - Performance of sizing images in front end after/and fetching raw sized images from backend 
 - Cleanliness of code lmao