### PR TITLE
Redid projects page query for members deeper

### DIFF
--- a/frontend/src/pages/ProjectPage.tsx
+++ b/frontend/src/pages/ProjectPage.tsx
@@ -14,7 +14,7 @@ let proj: null;
 function ProjectPage() {
     params = useParams();
 
-    const res = useAxios(process.env.REACT_APP_ROOT_URL + "/api/projects?populate=*&filters[path][$eq]=" + params.projectpath, "GET", {});
+    const res = useAxios(process.env.REACT_APP_ROOT_URL + "/api/projects?populate[members][populate]=*&populate[image]=*&filters[path][$eq]=" + params.projectpath, "GET", {});
     const project = res.data ? res.data["data"][0] : null;
     proj = project;
 
@@ -23,7 +23,7 @@ function ProjectPage() {
     if (proj){
     return (
         <div>
-            <Header/>
+            <Header/> 
             <TeamMembers/>
         </div>
     );
@@ -74,10 +74,9 @@ function TeamMembers() {
             members.map((item, index) => (
                 <Person key={index}
                 memberName={item["attributes"]["firstName"] + ' ' + item["attributes"]["lastName"]}
-                // role={(item['attributes']['componentRolesArr'] as Array<any>).find(e => e['isDisplayRole'] == true)['title']}
-                role=""
+                role={(item['attributes']['componentRolesArr'] as Array<any>).find(e => e['isDisplayRole'] == true)['title']}
                 pronouns={item["attributes"]["pronouns"]}
-                // src={item["attributes"]["avatar"]["data"] ? item["attributes"]["avatar"]["data"]["attributes"]["url"] : null}
+                src={item["attributes"]["avatar"]["data"] ? item["attributes"]["avatar"]["data"]["attributes"]["url"] : null}
                 />
             ))}
         </div>


### PR DESCRIPTION
- With this, the code to feed images and pronouns in works now on the individual project pages. 
See: https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/populating-fields.html#component-dynamic-zones
for more 

future considerations: 
- don't do this/query for less data per member because this is likely slow. we should only really need avatars and pronouns for the members, not thier past projects. 