### PR TITLE
Fixed footer to bottom of short pages

### DIFF
--- a/frontend/src/pages/ProjectPage.tsx
+++ b/frontend/src/pages/ProjectPage.tsx
@@ -20,7 +20,7 @@ function ProjectPage() {
 
     if (proj){
     return (
-        <div>
+        <div className={styles.content}>
             <Header/> 
             <TeamMembers/>
         </div>

--- a/frontend/src/styles/PageNotFound.module.css
+++ b/frontend/src/styles/PageNotFound.module.css
@@ -1,4 +1,5 @@
 .PageNotFound {
   margin-top: 250px;
   text-align: center;
+  min-height: calc(100vh - 815px - 250px);
 }

--- a/frontend/src/styles/apply/NonprofitApply.module.css
+++ b/frontend/src/styles/apply/NonprofitApply.module.css
@@ -1,3 +1,8 @@
+/* adjusting min-height so footer stays at the bottom of the page when zoomed out */
+.nonprofitApply {
+  min-height: calc(100vh - 815px);
+}
+
 .nonprofitApplyHeader p {
   text-align: center;
   margin: 0;
@@ -46,7 +51,6 @@
   text-align: center;
   padding: 0 11%;
   margin: 0;
-  max-width: 1200px;
 }
 
 .howToApply {
@@ -103,7 +107,7 @@
   }
 
   .howToApply p {
-    padding: 0 11%;
+    padding: 0 21%;
   }
 
   .faq {

--- a/frontend/src/styles/apply/StudentApply.module.css
+++ b/frontend/src/styles/apply/StudentApply.module.css
@@ -1,3 +1,7 @@
+/* adjusting min-height of content container so footer stays at the bottom of the page when zoomed out */
+.studentApply {
+  min-height: calc(100vh - 815px);
+}
 
 /* Mobile Styles */
 .studentApplyHeader h1 {

--- a/frontend/src/styles/projects/ProjectsPage.module.css
+++ b/frontend/src/styles/projects/ProjectsPage.module.css
@@ -1,3 +1,8 @@
+/* adjusting min-height so footer stays at the bottom of the page when zoomed out */
+.content {
+  min-height: calc(100vh - 815px);
+}
+
 .studentApplyHeader h1 {
   text-align: center;
   margin: 0;


### PR DESCRIPTION
Task in notion: https://www.notion.so/h4i/project-page-footers-not-fixed-to-bottom-of-page-issue-when-page-zoomed-out-327a6f8b6c3d4f069d2dcc03b164f582

The aim of this task was to fix the footer to the bottom of the project pages when zoomed out. I found that the issue was that, when zoomed out there wasn't enough content to fill the whole window and the content didn't have a minimum height. This was an issue for other pages with smaller amounts of content as well (student apply, nonprofit apply, and page not found). I addressed the issue on all of these pages by setting the minimum height of the content to be 100vh minus the height of the footer. To address this issue I had to use the css `calc()` function, which is advised against in the guidelines for this website, but after trying a number of different approaches I couldn't find another approach that worked for this website. Based on my research, it seems like using `calc()` for this kind of issue is pretty common and that sparing use of calc() doesn't slow webpages down like it used to. However, finding an alternative solution is something that could be revisited in the future. 

Another note is that I only added this fix to the affected pages (project pages, student apply, nonprofit apply, and page not found), but technically this issue would affect other pages if a user had a tall enough monitor and zoomed out really far. I tried applying this fix to App.tsx rather than the specific project pages, but I couldn't get the styling to show up. That's another thing that could be revisited on this issue in the future, but for now the issue should be solved for the vast majority of users. 

I visually tested that all of the pages I edited look as desired when very zoomed out, and I also double checked that my edits didn't change how they looked on standard sized screens, small screens, zoomed in screens, and on mobile. 

**Note**: I also fixed a bug on the nonprofit apply page that made the "how to apply" paragraph super small when zoomed out really far. It was an issue of how `padding: 11%` was interacting with `max-width: 1200px`. To fix the issue I adjusted the styling to match the paragraph in the header section. Now the  "how to apply" paragraph looks the same as it used to on standard and small/zoomed in screens, but the bug is fixed on super large/zoomed out screens. See the screenshots of the fix below. (Note that the FAQ section could probably still use some styling for zoomed out screens, but it's not as bad as the paragraph was and I didn't want to do too much outside the scope of my actual task).
before:
![before ](https://user-images.githubusercontent.com/81392398/195443541-ded996b8-fd97-465a-85db-26ab6af03d02.png)
after:
![after ](https://user-images.githubusercontent.com/81392398/195443595-327b5f82-a8f7-40dd-8bc6-bcd159a4178a.png)

