### PR TITLE
Refresh current page when page's nav link is clicked

### DIFF
--- a/frontend/src/components/navbar/Navbar.tsx
+++ b/frontend/src/components/navbar/Navbar.tsx
@@ -8,6 +8,17 @@ import { Link } from 'react-router-dom';
 const Navbar = () => {
   const [isMenuOpen, setMenuOpen] = useState(false);
 
+  function toggleAndReload(to:string) {
+    toggleMenu();
+    reload(to);
+  }
+
+  const reload = (to:string) => {
+    if (window.innerWidth > 1000 && window.location.pathname == to) {
+      window.location.reload();
+    }
+  };
+  
   const toggleMenu = () => {
     if (window.innerWidth <= 1000) {
       setMenuOpen(!isMenuOpen)
@@ -18,24 +29,24 @@ const Navbar = () => {
     <div>
       <div className={isMenuOpen ? styles.blurOverlay : `${styles.blurOverlay} ${styles.hidden}`}></div>
       <nav className={styles.navbarItems}>
-        <Link to="/">
+        <Link to="/" onClick={() => reload('/')}>
           <img alt="Hack4Impact Logo" className={styles.logo} src={h4iLogo}></img>
         </Link>
         <img className={styles.navIcon} src={isMenuOpen ? CloseButton : Hamburger} onClick={toggleMenu}/>
 
         <ul className={isMenuOpen ? styles.navMenu : `${styles.navMenu} ${styles.hidden}`}>
           <li>
-            <Link className={styles.navLinks} to={'/aboutus'} onClick={toggleMenu}>
+            <Link className={styles.navLinks} to={'/aboutus'} onClick={() => toggleAndReload('/aboutus')}>
               {'About Us'}
             </Link>
           </li>
           <li>
-            <Link className={styles.navLinks} to={'/ourwork'} onClick={toggleMenu}>
+            <Link className={styles.navLinks} to={'/ourwork'} onClick={() => toggleAndReload('/ourwork')}>
               {'Our Work'}
             </Link>
           </li>
           <li>
-            <Link className={styles.navLinks + ' ' + styles.applyDropdownButton} to={'/apply/student'} onClick={toggleMenu}>
+            <Link className={styles.navLinks + ' ' + styles.applyDropdownButton} to={'/apply/student'} onClick={() => toggleAndReload('/apply/student')}>
               Apply
             </Link>
             <div
@@ -43,12 +54,12 @@ const Navbar = () => {
             >
               <ul className={styles.applyDropdownContent}>
                 <li>
-                  <Link className={styles.navLinks} to={'/apply/student'} onClick={toggleMenu}>
+                  <Link className={styles.navLinks} to={'/apply/student'} onClick={() => toggleAndReload('/apply/student')}>
                     {'For Students'}
                   </Link>
                 </li>
                 <li>
-                  <Link className={styles.navLinks} to={'/apply/nonprofit'} onClick={toggleMenu}>
+                  <Link className={styles.navLinks} to={'/apply/nonprofit'} onClick={() => toggleAndReload('/apply/nonprofit')}>
                     {'For Nonprofits'}
                   </Link>
                 </li>

--- a/frontend/src/styles/home/Supporters.module.css
+++ b/frontend/src/styles/home/Supporters.module.css
@@ -35,7 +35,15 @@ a:hover {
     color: #0069ca;
 }
 
+/* mobile */
 #bloomburg {
-    width: 400px;
+    max-width: 275px;
     margin: 50px
+}
+
+@media screen and (min-width: 800px) {
+    #bloomburg {
+        max-width: 400px;
+        margin: 50px
+    }
 }


### PR DESCRIPTION
Notion task: https://www.notion.so/h4i/Refresh-when-Apply-For-Students-in-the-nav-bar-selected-93f629b545f74638b5fc59abd28c5bce

I updated the navbar so that if the link for the current page is clicked, the page is refreshed to show users that their click led to the page they were already on. I only implemented this for pages wide enough to have the full navbar (not the hamburger menu), since it felt unnecessary to both toggle the menu and reload the page when I tested it on smaller screens. However, if we want to toggle the menu and reload the page, that would be a very easy update. 

Since my changes apply to every page of the website, I tested that each page had the new desired behavior on large screens and that there were no changes to the navbar's behavior on small screens/mobile. 

Additional notes:
I also fixed a bug I found on the homepage. In the mobile view, the new bloomberg logo in the sponsorship section was making the page too wide so you couldn't see the hamburger menu. I fixed this by changing the max-width of the image on small screens. See the before and after below. 
Before: 
![Recording 2022-10-12 at 23 46 25](https://user-images.githubusercontent.com/81392398/195494633-836dddfb-14eb-4a80-a1f5-41fbeebb6de4.gif)
After: 
<img width="384" alt="Screen Shot 2022-10-12 at 23 44 06 " src="https://user-images.githubusercontent.com/81392398/195494606-46796292-bb79-468f-a222-b8bb5c6e6011.png">
