### PR TITLE
resize the scrollToTopButton for mobile mode

### DIFF
--- a/frontend/src/components/buttons/ScrollToTopButton.tsx
+++ b/frontend/src/components/buttons/ScrollToTopButton.tsx
@@ -27,11 +27,17 @@ const ScrollToTopButton: React.FC = () => {
 
   return (
     <div className={styles.ScrollToTopButton} onClick={scrollToTop} style={{ display: visible ? 'inline' : 'none' }}>
-      <img src={ScrollToTopButtonImg} aria-label="Scroll to Top Button" />
+      <img 
+        src={ScrollToTopButtonImg} 
+        aria-label="Scroll to Top Button" 
+        width={window.innerWidth <= 500 ? 59 : 64} // Check if in mobile mode
+        height={window.innerWidth <= 500 ? 59 : 64}/>
       <img
         className={styles.ScrollToTopButtonHover}
         src={ScrollToTopButtonHoverImg}
         aria-label="Scroll to Top Button Hover"
+        width={window.innerWidth <= 500 ? 59 : 64}
+        height={window.innerWidth <= 500 ? 59 : 64}
       />
     </div>
   );

--- a/frontend/src/styles/buttons/ScrollToTopButton.module.css
+++ b/frontend/src/styles/buttons/ScrollToTopButton.module.css
@@ -1,7 +1,7 @@
 .ScrollToTopButton {
     position: fixed;
     display: inline-block;
-    right: 2%;
+    right: 1%;
     bottom: 20%;
     z-index: 99;
     cursor: pointer;


### PR DESCRIPTION
resized the scrollToTopButton image for mobile mode. It is "64px" for desktop and "59px" for mobile mode.