### PR TITLE
Fixed sponsorship contact link to go to the Contact Us page

### DIFF
--- a/frontend/src/components/home_page/Supporters.tsx
+++ b/frontend/src/components/home_page/Supporters.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styles from '../../styles/home/Supporters.module.css';
 import bloomburgLogo from '../assets/supporters/Bloomberg.png';
+import { Link } from 'react-router-dom';
 
 const Supporters = () => {
     return (
@@ -12,7 +13,9 @@ const Supporters = () => {
                 <img src={bloomburgLogo} id={styles.bloomburg}/>
             </div>
             {/* <h4 className={styles.divider}><span>BRONZE</span></h4> */}
-            <a href={'mailto:umd@hack4impact.org'}>{'Interested in partnering? Contact us!'}</a>
+            <Link className={styles.navLinks} to={'/contactus'}>
+              {'Interested in partnering? Contact us!'}
+            </Link>
         </div>
     );
 };


### PR DESCRIPTION
Notion task: https://www.notion.so/h4i/contact-us-link-under-sponsorship-section-should-take-users-to-the-contact-us-page-552a748e0a854e96a8704df338a371f4

Updated contact link in the sponsorship section of the homepage to take users to the Contact Us page, rather than opening email application.