### PR TITLE
Investigate eboard photo loading for Christine Niu

### DIFF
--- a/frontend/src/components/Person.tsx
+++ b/frontend/src/components/Person.tsx
@@ -14,7 +14,12 @@ function Person(props: any) {
   if (props.src == undefined || props.src == null) {
     imageSrc = default_pfp;
   } else {
-    imageSrc = props.src;
+    // If the image URL is relative (starts with /), prepend the backend URL
+    if (props.src.startsWith('/')) {
+      imageSrc = process.env.REACT_APP_ROOT_URL + props.src;
+    } else {
+      imageSrc = props.src;
+    }
   }
 
   return (


### PR DESCRIPTION
When photos are uploaded to Strapi and stored locally instead of on Cloudinary, they return relative URLs (e.g., /uploads/photo.png). The Person component now checks if the URL is relative and prepends the backend URL to ensure images load correctly.

This fixes the issue where Steven Ha and Christine Niu's photos were not displaying on the eboard page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image loading in the Person component to properly handle both relative and absolute image URLs from the backend.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->